### PR TITLE
ASB 2017.11 (Pixel/Nexus bulletin, section "Runtime")

### DIFF
--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -257,6 +257,8 @@ static int rc4_hmac_md5_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)
 
 		if (!ctx->encrypt)
 			{
+			if (len < MD5_DIGEST_LENGTH)
+				return -1;
 			len -= MD5_DIGEST_LENGTH;
 			p[arg-2] = len>>8;
 			p[arg-1] = len;

--- a/crypto/evp/encode.c
+++ b/crypto/evp/encode.c
@@ -137,7 +137,7 @@ void EVP_EncodeUpdate(EVP_ENCODE_CTX *ctx, unsigned char *out, int *outl,
 	*outl=0;
 	if (inl == 0) return;
 	OPENSSL_assert(ctx->length <= (int)sizeof(ctx->enc_data));
-	if ((ctx->num+inl) < ctx->length)
+        if (ctx->length - ctx->num > inl) 
 		{
 		memcpy(&(ctx->enc_data[ctx->num]),in,inl);
 		ctx->num+=inl;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -343,7 +343,7 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
 	OPENSSL_assert(bl <= (int)sizeof(ctx->buf));
 	if (i != 0)
 		{
-		if (i+inl < bl)
+		if (bl - i > inl)
 			{
 			memcpy(&(ctx->buf[i]),in,inl);
 			ctx->buf_len+=inl;


### PR DESCRIPTION
ASB 2017.11 (Pixel/Nexus bulletin, Runtime)
CVE-2016-2105   A-63710022*   RCE  Moderate  5.0.2, 5.1.1
CVE-2016-2106   A-63709511*   RCE  Moderate  5.0.2, 5.1.1
CVE-2017-3731   A-63710076*   ID      Moderate  5.0.2, 5.1.1
(Flagged by Google as "non-public", but I found them)

